### PR TITLE
Adding queryGenerator options to mongoose-batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
  **setup: myModel.js**
 
 ```
-var findInBatches = require('mongoose-batches'); 
+var findInBatches = require('mongoose-batches');
 
 var myModel = new Schema({
   //... Your Schema Here
@@ -15,7 +15,7 @@ var myModel = new Schema({
 myModel.plugin(findInBatches);
 
 //... etc
-``` 
+```
 
 **usage: someFile.js**
 
@@ -35,15 +35,16 @@ myModel.findInBatches(query, options, function (err, docs, next) {
 ## About the parameters
 - 1st param is the query to send to `myModel.Find`
 
-- 2nd param is the options, currenty only batchSize and select. 
+- 2nd param is the options, currenty only batchSize, select, and queryGenerator.
+  - queryGenerator is a function used to modify the query in addition to the query parameter that is passed to `myModel.Find`. It allows you to use the predefined queries build onto the model.
 
 - 3rd param is the "Batch Handler". A function that receives each batch of documents.
-  - The batch handler's parameters are 
-     - 1 any errors returned from the find query 
+  - The batch handler's parameters are
+     - 1 any errors returned from the find query
      - 2 (Array) the batch of documents
      - 3 the function to invoke the next batch. (explicitly passing in 'cancel' to nextBatch will stop the operation and invoke the final promise. `nextBatch('cancel')`)
      - 4 The count of docs that matched the query
-     - 5 The amount of docs left to find (actual documents unprocessed by your batchHandler can be found by (documentsRemaining + docs.length) ) 
+     - 5 The amount of docs left to find (actual documents unprocessed by your batchHandler can be found by (documentsRemaining + docs.length) )
 
 ## Options
 ```
@@ -53,6 +54,9 @@ var options = {
         name : 1,
         email : 1,
         phone : 1
+    },
+    queryGenerator: function(query) {
+      return query.where({ name: {$ne: null}})
     }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -30,9 +30,10 @@ module.exports = function (schema) {
     return new promise.Promise(function (resolve, reject) {
 
       var query = this.find(find);
-      if (opts.queryGenerator) query = opts.queryGenerator(query)
-
-      (opts.queryGenerator ? opts.queryGenerator(this.find(find)) : this.find(find)).count().exec(function (err, count) {
+      if (opts.queryGenerator) query = opts.queryGenerator(query);
+      var countQuery = this.find(find);
+      if (opts.queryGenerator) countQuery = opts.queryGenerator(countQuery);
+      countQuery.count().exec(function (err, count) {
 
         var documentsRemaining = count;
 

--- a/index.js
+++ b/index.js
@@ -30,9 +30,13 @@ module.exports = function (schema) {
     return new promise.Promise(function (resolve, reject) {
 
       var query = this.find(find);
-      if (opts.queryGenerator) query = opts.queryGenerator(query);
       var countQuery = this.find(find);
-      if (opts.queryGenerator) countQuery = opts.queryGenerator(countQuery);
+
+      if (opts.queryGenerator) {
+        query = opts.queryGenerator(query);
+        countQuery = opts.queryGenerator(countQuery);
+      }
+
       countQuery.count().exec(function (err, count) {
 
         var documentsRemaining = count;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (schema) {
 
 
   schema.statics.findInBatches = schema.statics.findInBatches || function (find, opts, batchHandler) {
-      
+
     find = (typeof find === 'object' && find) || {};
 
     opts = options(opts || {});
@@ -30,11 +30,12 @@ module.exports = function (schema) {
     return new promise.Promise(function (resolve, reject) {
 
       var query = this.find(find);
+      if (opts.queryGenerator) query = opts.queryGenerator(query)
 
-      this.find(find).count().exec(function (err, count) {
-        
+      (opts.queryGenerator ? opts.queryGenerator(this.find(find)) : this.find(find)).count().exec(function (err, count) {
+
         var documentsRemaining = count;
-        
+
         var processBatch = function (cancel) {
 
           if (cancel === 'cancel') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+   "name": "mongoose-batches",
+   "version": "0.0.2",
+   "lockfileVersion": 1,
+   "requires": true,
+   "dependencies": {
+      "bluebird": {
+         "version": "2.11.0",
+         "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+         "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+      }
+   }
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,27 @@
 {
-   "name" : "mongoose-batches",
-   "main" : "index.js",
-   "version": "0.0.1",
+   "name": "mongoose-batches",
+   "main": "index.js",
+   "version": "0.0.2",
    "description": "A Mongoose plugin to work with large amounts of data via async batch processing.",
    "author": "Charlie Mitchell <charliesemailis@gmail.com>",
    "license": "MIT",
-   "keywords" : [ "in batches", "find in batches", "mongoose batch", "batch processing", "mongoose async", "async batch processing"],
+   "keywords": [
+      "in batches",
+      "find in batches",
+      "mongoose batch",
+      "batch processing",
+      "mongoose async",
+      "async batch processing"
+   ],
    "bugs": {
-     "url": "http://github.com/charliemitchell/mongoose-batches",
-     "email": "charliesemailis@gmail.com"
+      "url": "http://github.com/charliemitchell/mongoose-batches",
+      "email": "charliesemailis@gmail.com"
    },
    "repository": {
-     "type": "git",
-     "url": "http://github.com/charliemitchell/mongoose-batches.git"
+      "type": "git",
+      "url": "http://github.com/charliemitchell/mongoose-batches.git"
    },
    "dependencies": {
-      "bluebird" : "^2.9.x"
+      "bluebird": "^2.9.x"
    }
 }


### PR DESCRIPTION
With mongoose models we can pre-define queries on the model
e.g.
```javascript
Schema.query.byName = function(name) { return this.where({ name })}
``` 
Sometimes those logics can be very complex thus to increase maintainability - the queryGenerator option will allow one to utilize these functions with mongoose-batches.